### PR TITLE
Implemented hashing on IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,14 @@
 //! Bardic provides performant building blocks for creating large-scale
 //! procedural narrative generators.
 
-/// Provides a way to manage and reference unique IDs for
-/// entities in the system.
+/// Provides types for managing unique IDs within a system.
+/// 
+/// IDs can be used to represent properties/states of entities
+/// without needing to use strings or other more complex types.
+/// This improves memory and run-time performance.
+/// 
+/// The [id::IdManager] struct can be used to validate ID usage
+/// at initialization.
 pub mod id;
 
 /// Provides functionality for procedural text generation.


### PR DESCRIPTION
Changed the ID API to remove the public `Id` class and instead always return `IdRef` from `IdManager` calls.

Implemented `Hash` on `IdRef`.